### PR TITLE
Bumping the nodepool-asg version

### DIFF
--- a/modules/node-pool/main.tf
+++ b/modules/node-pool/main.tf
@@ -51,7 +51,7 @@ resource "aws_iam_instance_profile" "this" {
 
 module "nodepool-asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   # Auto scaling group
   asg_name                    = var.name


### PR DESCRIPTION
Bumping AWS nodepool-asg module version to 4 to try and fix launch instance issue. 