### PR TITLE
Add missing autoscaler enabled tag and allow the user to provide tags to the node group

### DIFF
--- a/modules/node-pool/main.tf
+++ b/modules/node-pool/main.tf
@@ -94,5 +94,5 @@ module "nodepool-asg" {
     },
   ]
 
-  tags = flatten([local.cluster_id, local.cluster_name, local.cluster_autoscaler_tags, local.cluster_autoscaler_gpu_tags])
+  tags = flatten([local.cluster_id, local.cluster_name, local.cluster_autoscaler_tags, local.cluster_autoscaler_gpu_tags, var.tags])
 }

--- a/modules/node-pool/main.tf
+++ b/modules/node-pool/main.tf
@@ -31,11 +31,18 @@ locals {
     propagate_at_launch = true
   }
 
-  cluster_autoscaler_tags = var.cluster_autoscaler ? {
-    key                 = "k8s.io/cluster-autoscaler/${data.aws_eks_cluster.this.id}"
-    value               = "owned"
-    propagate_at_launch = true
-  } : {}
+  cluster_autoscaler_tags = var.cluster_autoscaler ? [
+    {
+      key                 = "k8s.io/cluster-autoscaler/${data.aws_eks_cluster.this.id}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "k8s.io/cluster-autoscaler/enabled"
+      value               = "true"
+      propagate_at_launch = false
+    },
+  ] : {}
 
   cluster_autoscaler_gpu_tags = var.gpu_enabled ? {
     key                 = "k8s.io/cluster-autoscaler/node-template/gpu-enabled"

--- a/modules/node-pool/variables.tf
+++ b/modules/node-pool/variables.tf
@@ -80,3 +80,9 @@ variable "role_name" {
   type        = string
   description = "The role that should be applied"
 }
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags to apply to the node pool"
+  default     = {}
+}


### PR DESCRIPTION
Autoscaling groups created by the module are missing the tag that the k8s aws cluster autoscaler looks for