### PR TITLE
Use private fork of AWS autoscaler to enable lifecycle management

### DIFF
--- a/modules/node-pool/main.tf
+++ b/modules/node-pool/main.tf
@@ -76,8 +76,8 @@ resource "aws_iam_instance_profile" "this" {
 }
 
 module "nodepool-asg" {
-  source  = "terraform-aws-modules/autoscaling/aws"
-  version = "4.4.0"
+  source  = "bbriggs/autoscaling/aws"
+  version = "4.9.0"
 
   # Auto scaling group
   vpc_zone_identifier         = toset([data.aws_subnet.this.id])


### PR DESCRIPTION
This module currently resets ASG sizes to the desired capacity (usually 0) on every run. The upstream AWS Autoscaling module does not expose this for management by users. To fix this, we have created a temporary private fork of the Autoscaling module and added the required feature while @bbriggs submits a patch upstream.

This patch naively ignores all changes to the ASG's `desired_capacity` and will likely get a configuration option to fix this in an upcoming change.
