### PR TITLE
Fix missing taints

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,4 +21,5 @@ module "nodepools" {
   role_name                   = var.role_name
   tags                        = var.tags
   k8s_labels                  = var.k8s_labels
+  k8s_taints                  = var.k8s_taints
 }


### PR DESCRIPTION
Looks like the foreach parent module was missing the k8s_taints key so the variable wasn't being included.

Fixes: https://gohypergiant.atlassian.net/browse/EAIP-2256